### PR TITLE
Move keybindings out of the main Mod core to prevent side violation.

### DIFF
--- a/src/main/java/baguchan/redstonemecha/RedstoneMechaCore.java
+++ b/src/main/java/baguchan/redstonemecha/RedstoneMechaCore.java
@@ -8,9 +8,12 @@ import baguchan.redstonemecha.network.MechaPacketHandler;
 import net.minecraft.block.Block;
 import net.minecraft.client.settings.KeyBinding;
 import net.minecraft.item.Item;
+import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.DistExecutor;
 import net.minecraftforge.fml.client.registry.ClientRegistry;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
@@ -24,10 +27,6 @@ import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 @Mod("redstonemecha")
 public class RedstoneMechaCore
 {
-    public final KeyBinding keyBindAction0 = new KeyBinding("key.redstonemecha.action0", 320, "key.categories.redstonemecha");
-    public final KeyBinding keyBindAction1 = new KeyBinding("key.redstonemecha.action1", 321, "key.categories.redstonemecha");
-    public final KeyBinding keyBindAction2 = new KeyBinding("key.redstonemecha.action2", 322, "key.categories.redstonemecha");
-
     // Directly reference a log4j logger.
     public static final String MODID = "redstonemecha";
     public static RedstoneMechaCore instance;
@@ -43,26 +42,17 @@ public class RedstoneMechaCore
         // Register the processIMC method for modloading
         FMLJavaModLoadingContext.get().getModEventBus().addListener(this::processIMC);
         // Register the doClientStuff method for modloading
-        FMLJavaModLoadingContext.get().getModEventBus().addListener(this::doClientStuff);
+        DistExecutor.runWhenOn(Dist.CLIENT, () -> () -> FMLJavaModLoadingContext.get().getModEventBus().addListener(ClientRegistrar::setup));
         // Register ourselves for server and other game events we are interested in
         MinecraftForge.EVENT_BUS.register(this);
+
+
     }
 
     private void setup(final FMLCommonSetupEvent event)
     {
         // some preinit code
         GearTypeRegister.registerGearType();
-    }
-
-    private void doClientStuff(final FMLClientSetupEvent event) {
-        ClientRegistrar.render();
-  /*      event.getMinecraftSupplier().get().gameSettings.setKeyBindingCode(keyBindAction0,keyBindAction0.getDefault());
-        event.getMinecraftSupplier().get().gameSettings.setKeyBindingCode(keyBindAction1,keyBindAction1.getDefault());
-        event.getMinecraftSupplier().get().gameSettings.setKeyBindingCode(keyBindAction2,keyBindAction2.getDefault());
-*/
-        ClientRegistry.registerKeyBinding(keyBindAction0);
-        ClientRegistry.registerKeyBinding(keyBindAction1);
-        ClientRegistry.registerKeyBinding(keyBindAction2);
     }
 
     private void enqueueIMC(final InterModEnqueueEvent event)

--- a/src/main/java/baguchan/redstonemecha/client/render/ClientRegistrar.java
+++ b/src/main/java/baguchan/redstonemecha/client/render/ClientRegistrar.java
@@ -5,15 +5,33 @@ import baguchan.redstonemecha.client.screen.MechaTableScreen;
 import baguchan.redstonemecha.entity.RedWorkerEntity;
 import baguchan.redstonemecha.init.MechaContainers;
 import net.minecraft.client.gui.ScreenManager;
+import net.minecraft.client.settings.KeyBinding;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
+import net.minecraftforge.fml.client.registry.ClientRegistry;
 import net.minecraftforge.fml.client.registry.RenderingRegistry;
+import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 
 @OnlyIn(Dist.CLIENT)
 public class ClientRegistrar {
+    public static final KeyBinding keyBindAction0 = new KeyBinding("key.redstonemecha.action0", 320, "key.categories.redstonemecha");
+    public static final KeyBinding keyBindAction1 = new KeyBinding("key.redstonemecha.action1", 321, "key.categories.redstonemecha");
+    public static final KeyBinding keyBindAction2 = new KeyBinding("key.redstonemecha.action2", 322, "key.categories.redstonemecha");
+
     public static void render(){
         RenderingRegistry.registerEntityRenderingHandler(RedWorkerEntity.class, RedWorkerRender::new);
         ScreenManager.registerFactory(MechaContainers.MECHATABLE, MechaTableScreen::new);
         ScreenManager.registerFactory(MechaContainers.MECHA_INVENTORY, MechaInventoryScreen::new);
+    }
+
+    public static void setup (final FMLCommonSetupEvent event) {
+        ClientRegistrar.render();
+  /*      event.getMinecraftSupplier().get().gameSettings.setKeyBindingCode(keyBindAction0,keyBindAction0.getDefault());
+        event.getMinecraftSupplier().get().gameSettings.setKeyBindingCode(keyBindAction1,keyBindAction1.getDefault());
+        event.getMinecraftSupplier().get().gameSettings.setKeyBindingCode(keyBindAction2,keyBindAction2.getDefault());
+*/
+        ClientRegistry.registerKeyBinding(keyBindAction0);
+        ClientRegistry.registerKeyBinding(keyBindAction1);
+        ClientRegistry.registerKeyBinding(keyBindAction2);
     }
 }

--- a/src/main/java/baguchan/redstonemecha/entity/MechaBaseEntity.java
+++ b/src/main/java/baguchan/redstonemecha/entity/MechaBaseEntity.java
@@ -1,6 +1,7 @@
 package baguchan.redstonemecha.entity;
 
 import baguchan.redstonemecha.RedstoneMechaCore;
+import baguchan.redstonemecha.client.render.ClientRegistrar;
 import baguchan.redstonemecha.container.MechaContainer;
 import baguchan.redstonemecha.network.MechaPacketHandler;
 import net.minecraft.client.Minecraft;
@@ -171,15 +172,15 @@ public class MechaBaseEntity extends MobEntity{
                 MechaPacketHandler.pushSpaceStart(this);
             }
 
-            if (RedstoneMechaCore.instance.keyBindAction0.isKeyDown()) {
+            if (ClientRegistrar.keyBindAction0.isKeyDown()) {
                 MechaPacketHandler.pushActionStart(this, 0);
             }
 
-            if (RedstoneMechaCore.instance.keyBindAction1.isKeyDown()) {
+            if (ClientRegistrar.keyBindAction1.isKeyDown()) {
                 MechaPacketHandler.pushActionStart(this, 1);
             }
 
-            if (RedstoneMechaCore.instance.keyBindAction2.isKeyDown()) {
+            if (ClientRegistrar.keyBindAction2.isKeyDown()) {
                 MechaPacketHandler.pushActionStart(this, 2);
             }
         }


### PR DESCRIPTION
These are the changes I made for Redstone Mecha to run on DevCraft.

Feel free to use them or adapt them however you will, or discard and re-write it in the way that you wish.